### PR TITLE
Expose validLanguages as configuration setting to use this extension in more languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@ Autocorrect from quotes to backticks within javascript and typescript files
 ## Extension Settings
 
 * `template-string-converter.enable`: enable/disable this extension
+* `template-string-converter.validLanguages`: an array of valid languages to run the extension on
 * `template-string-converter.quoteType`: both, single, or double 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,16 @@
             "type": "boolean",
             "description": "extension is enabled",
             "default": true
+          },
+          "template-string-converter.validLanguages": {
+            "type": "array",
+            "description": "extension runs on these languages",
+            "default": [
+                "typescript",
+                "javascript",
+                "typescriptreact",
+                "javascriptreact"
+            ]
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,13 +8,8 @@ export function activate(context: vscode.ExtensionContext) {
     );
     let enabled = configuration.get<{}>("template-string-converter.enabled");
     let changes = e.contentChanges[0];
-    let validLanguages = [
-      "typescript",
-      "javascript",
-      "typescriptreact",
-      "javascriptreact",
-    ];
-    if (enabled && changes && validLanguages.includes(e.document.languageId)) {
+    let validLanguages = configuration.get<string[]>("template-string-converter.validLanguages");
+    if (enabled && changes && validLanguages?.includes(e.document.languageId)) {
       try {
         let lineNumber = changes.range.start.line;
         let currentChar = changes.range.start.character;


### PR DESCRIPTION
Nice extension! I always have to change my strings in my Vue projects but this extension does not work for other languages than the default 4. This PR exposes validLanguages as a configuration setting with the original entries as the default.