### PR TITLE
Replace tabs with spaces in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
                   "type": "object",
                   "properties": {
                     "when": {
-                      "type": "string", 
+                      "type": "string",
                       "pattern": "\\w*\\$\\(basename\\)\\w*",
                       "default": "$(basename).ext",
                       "description": "Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name."

--- a/package.json
+++ b/package.json
@@ -81,27 +81,27 @@
             ]
           },
           "template-string-converter.filesExcluded": {
-			"type": "object",
-			"markdownDescription": "Configure glob patterns for excluding files and folders.",
-			"additionalProperties": {
-				"anyOf": [
-					{
-						"type": "boolean",
-						"description": "The glob pattern to match file paths against. Set to true or false to enable or disable the pattern."
-					},
-					{
-						"type": "object",
-						"properties": {
-							"when": {
-								"type": "string", 
-								"pattern": "\\w*\\$\\(basename\\)\\w*",
-								"default": "$(basename).ext",
-								"description": "Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name."
-							}
-						}
-					}
-				]
-			}
+            "type": "object",
+            "markdownDescription": "Configure glob patterns for excluding files and folders.",
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "description": "The glob pattern to match file paths against. Set to true or false to enable or disable the pattern."
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "when": {
+                      "type": "string", 
+                      "pattern": "\\w*\\$\\(basename\\)\\w*",
+                      "default": "$(basename).ext",
+                      "description": "Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name."
+                    }
+                  }
+                }
+              ]
+            }
           }
         }
       }


### PR DESCRIPTION
The new entry to package.json uses tabs rather than spaces - this PR fixes the formatting.