### PR TITLE
Remove equality check against object since it will always return false

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
     const autoClosingBrackets = configuration.get<{}>("editor.autoClosingBrackets");
     const convertOutermostQuotes = configuration.get<boolean>("template-string-converter.convertOutermostQuotes");
     const convertWithinTemplateString = configuration.get<boolean>("template-string-converter.convertWithinTemplateString");
-    const filesExcluded: { key: string, value: boolean } | undefined | {} = configuration.get<object>("template-string-converter.filesExcluded")
+    const filesExcluded = configuration.get<{[key: string]: boolean}>("template-string-converter.filesExcluded")
     if (
       enabled &&
       quoteType &&
@@ -406,7 +406,7 @@ const hasBacktick = (lineIndex: number, currentLine: string, document: vscode.Te
   return false;
 };
 
-function includeFile(fileName: string, exclusions?: { key: string, value: boolean } | {}): boolean {
+function includeFile(fileName: string, exclusions?: { [key: string]: boolean }): boolean {
   if (!exclusions) {
     return true;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
     const autoClosingBrackets = configuration.get<{}>("editor.autoClosingBrackets");
     const convertOutermostQuotes = configuration.get<boolean>("template-string-converter.convertOutermostQuotes");
     const convertWithinTemplateString = configuration.get<boolean>("template-string-converter.convertWithinTemplateString");
-    const filesExcluded = configuration.get<{[key: string]: boolean}>("template-string-converter.filesExcluded")
+    const filesExcluded = configuration.get<{[key: string]: boolean}>("template-string-converter.filesExcluded");
     if (
       enabled &&
       quoteType &&

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -407,7 +407,7 @@ const hasBacktick = (lineIndex: number, currentLine: string, document: vscode.Te
 };
 
 function includeFile(fileName: string, exclusions?: { key: string, value: boolean } | {}): boolean {
-  if (!exclusions || exclusions === {}) {
+  if (!exclusions) {
     return true;
   }
   for (const [key, value] of Object.entries(exclusions))


### PR DESCRIPTION
See https://devblogs.microsoft.com/typescript/announcing-typescript-4-8-beta/#errors-when-comparing-object-and-array-literals

The comparison with {} will always return false. Additionally, since we loop through Object.entries() the check isn't needed anyway as we only save the initialization overhead in the rare cases the setting is set to the empty object.

I believe that in TS 4.8 and onwards, this kind of comparison will result in an error.

This CL removes that check, and also makes the typing a bit clearer. #79 proposes a change to how we store this configuration in settings.json in a simpler format.