### PR TITLE
Simplify the setting template-string-converter.filesExcluded

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
           },
           "template-string-converter.validLanguages": {
             "type": "array",
+            "items": { "type": "string" },
             "description": "the extension runs on these languages",
             "default": [
               "svelte",
@@ -82,7 +83,8 @@
           },
           "template-string-converter.filesExcluded": {
             "type": "array",
-            "description": "Configure glob patterns for excluding files and folders.",
+            "items": { "type": "string" },
+            "description": "configure glob patterns for excluding files and folders",
             "default": []
           }
         }

--- a/package.json
+++ b/package.json
@@ -81,27 +81,9 @@
             ]
           },
           "template-string-converter.filesExcluded": {
-            "type": "object",
-            "markdownDescription": "Configure glob patterns for excluding files and folders.",
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "boolean",
-                  "description": "The glob pattern to match file paths against. Set to true or false to enable or disable the pattern."
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "when": {
-                      "type": "string",
-                      "pattern": "\\w*\\$\\(basename\\)\\w*",
-                      "default": "$(basename).ext",
-                      "description": "Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name."
-                    }
-                  }
-                }
-              ]
-            }
+            "type": "array",
+            "description": "Configure glob patterns for excluding files and folders.",
+            "default": []
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
     const autoClosingBrackets = configuration.get<{}>("editor.autoClosingBrackets");
     const convertOutermostQuotes = configuration.get<boolean>("template-string-converter.convertOutermostQuotes");
     const convertWithinTemplateString = configuration.get<boolean>("template-string-converter.convertWithinTemplateString");
-    const filesExcluded = configuration.get<string[]|{[key: string]: boolean}>("template-string-converter.filesExcluded")
+    const filesExcluded = configuration.get<string[]|{[key: string]: boolean}>("template-string-converter.filesExcluded");
     if (
       enabled &&
       quoteType &&
@@ -407,10 +407,17 @@ const hasBacktick = (lineIndex: number, currentLine: string, document: vscode.Te
 };
 
 function includeFile(fileName: string, exclusions?: string[]|{[key: string]: boolean}): boolean {
+  // Support for any users with the old setting.
   if (exclusions && !Array.isArray(exclusions)) {
-    // Support for any users with the old setting.
-    return !Object.entries(exclusions).some(([key: string, value: boolean]) => value && fileName.match(key));
+    const newExclusions: string[] = [];
+    for (const [key, value] of Object.entries(exclusions)) {
+      if (value) {
+        newExclusions.push(key);
+      }
+    }
+    exclusions = newExclusions;
   }
+  
   return !exclusions?.some(match => fileName.match(match));
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
     const autoClosingBrackets = configuration.get<{}>("editor.autoClosingBrackets");
     const convertOutermostQuotes = configuration.get<boolean>("template-string-converter.convertOutermostQuotes");
     const convertWithinTemplateString = configuration.get<boolean>("template-string-converter.convertWithinTemplateString");
-    const filesExcluded = configuration.get<string[]>("template-string-converter.filesExcluded")
+    const filesExcluded = configuration.get<string[]|{[key: string]: boolean}>("template-string-converter.filesExcluded")
     if (
       enabled &&
       quoteType &&
@@ -406,7 +406,11 @@ const hasBacktick = (lineIndex: number, currentLine: string, document: vscode.Te
   return false;
 };
 
-function includeFile(fileName: string, exclusions?: string[]): boolean {
+function includeFile(fileName: string, exclusions?: string[]|{[key: string]: boolean}): boolean {
+  if (exclusions && !Array.isArray(exclusions)) {
+    // Support for any users with the old setting.
+    return !Object.entries(exclusions).some(([key: string, value: boolean]) => value && fileName.match(key));
+  }
   return !exclusions?.some(match => fileName.match(match));
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
     const autoClosingBrackets = configuration.get<{}>("editor.autoClosingBrackets");
     const convertOutermostQuotes = configuration.get<boolean>("template-string-converter.convertOutermostQuotes");
     const convertWithinTemplateString = configuration.get<boolean>("template-string-converter.convertWithinTemplateString");
-    const filesExcluded: { key: string, value: boolean } | undefined | {} = configuration.get<object>("template-string-converter.filesExcluded")
+    const filesExcluded = configuration.get<string[]>("template-string-converter.filesExcluded")
     if (
       enabled &&
       quoteType &&
@@ -406,17 +406,8 @@ const hasBacktick = (lineIndex: number, currentLine: string, document: vscode.Te
   return false;
 };
 
-function includeFile(fileName: string, exclusions?: { key: string, value: boolean } | {}): boolean {
-  if (!exclusions || exclusions === {}) {
-    return true;
-  }
-  for (const [key, value] of Object.entries(exclusions))
-    if (value) {
-      if (fileName.match(key)) {
-        return false;
-      }
-    }
-  return true;
+function includeFile(fileName: string, exclusions?: string[]): boolean {
+  return !exclusions?.some(match => fileName.match(match));
 }
 
 const getQuoteChar = (type: QuoteType): QuoteChar => {


### PR DESCRIPTION
This setting works currently be looping over all keys in the provided object and if the value is truthy, it will compare the filepath against the object key, and if that matches it will exclude the file.

In practice, the setting is just a list of patterns which are checked, and that can be implemented in a much simpler way, which will also allow for the settings to be configured in the settings editor, rather than requiring settings.json to be manually edited.

I have done a quick google, and there is nothing referencing this setting other than the issue #58 that requested it. I think it should be safe to make changes to that setting.

