### PR TITLE
Allow semicolon when adding brackets to props

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,7 @@ export function activate(context: vscode.ExtensionContext) {
             const endLine = e.document.lineCount - lineNumber > 20 ? lineNumber + 20 : e.document.lineCount;
             const multiLineText = e.document.getText(new vscode.Range(startLine, 0, endLine, 200));
             let matches = multiLineText.match(regex);
-            if (lineText.includes(';') || lineText.includes(",") || lineText.substring(0, currentChar).includes(":")) {
+            if (lineText.includes(",") || lineText.substring(0, currentChar).includes(":")) {
               // treat as a single line
               matches = null;
             }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -69,6 +69,24 @@ suite('Extension Test Suite', () => {
 			assert.strictEqual(doc.getText(), '"\\${"');
 		});
 	});
+
+	let JSXTag = '"<div className="hello $"/>"';
+	test('add bracket to JSX', () => {
+		return withRandomFileEditor(JSXTag, 'ts', async (editor, doc) => {
+			await editor.insertSnippet(new vscode.SnippetString("{"), new vscode.Position(0, 24));
+			await delay(500);
+			assert.strictEqual(doc.getText(), '"<div className={`hello ${}`}/>"');
+		});
+	});
+
+	let JSXTagWithSemicolon = '"<div className="hello $"/>;"';
+	test('add bracket to JSX with ;', () => {
+		return withRandomFileEditor(JSXTagWithSemicolon, 'ts', async (editor, doc) => {
+			await editor.insertSnippet(new vscode.SnippetString("{"), new vscode.Position(0, 24));
+			await delay(500);
+			assert.strictEqual(doc.getText(), '"<div className={`hello ${}`}/>;"');
+		});
+	});
 });
 export function delay(ms: number) {
 	return new Promise(resolve => setTimeout(resolve, ms));

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -70,18 +70,18 @@ suite('Extension Test Suite', () => {
 		});
 	});
 
-	let JSXTag = '"<div className="hello $"/>"';
-	test('add bracket to JSX', () => {
-		return withRandomFileEditor(JSXTag, 'ts', async (editor, doc) => {
+	let htmlTag = '"<div className="hello $"/>"';
+	test('add bracket to htmlTag', () => {
+		return withRandomFileEditor(htmlTag, 'ts', async (editor, doc) => {
 			await editor.insertSnippet(new vscode.SnippetString("{"), new vscode.Position(0, 24));
 			await delay(500);
 			assert.strictEqual(doc.getText(), '"<div className={`hello ${}`}/>"');
 		});
 	});
 
-	let JSXTagWithSemicolon = '"<div className="hello $"/>;"';
-	test('add bracket to JSX with ;', () => {
-		return withRandomFileEditor(JSXTagWithSemicolon, 'ts', async (editor, doc) => {
+	let htmlTagWithSemicolon = '"<div className="hello $"/>;"';
+	test('add bracket to htmlTag with ;', () => {
+		return withRandomFileEditor(htmlTagWithSemicolon, 'ts', async (editor, doc) => {
 			await editor.insertSnippet(new vscode.SnippetString("{"), new vscode.Position(0, 24));
 			await delay(500);
 			assert.strictEqual(doc.getText(), '"<div className={`hello ${}`}/>;"');


### PR DESCRIPTION
Bug Fix https://github.com/meganrogge/template-string-converter/issues/71

Remove `;` check to allow AddBracketsToProps to work for JSX with `;` .
Tests have been added in typescript to check that brackets are added with and without `;` .