### PR TITLE
feat: add Astro and Vue language support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "onLanguage:typescript",
     "onLanguage:javascript",
     "onLanguage:typescriptreact",
-    "onLanguage:javascriptreact"
+    "onLanguage:javascriptreact",
+    "onLanguage:astro",
+    "onLanguage:vue"
   ],
   "license": "MIT",
   "galleryBanner": {
@@ -80,7 +82,9 @@
               "typescript",
               "javascript",
               "typescriptreact",
-              "javascriptreact"
+              "javascriptreact",
+              "astro",
+              "vue"
             ]
           },
           "template-string-converter.filesExcluded": {


### PR DESCRIPTION
Add astro and vue to activationEvents and validLanguages defaults so the extension activates and converts template strings in these files.